### PR TITLE
fix getting wrong tablename when table prefix exits

### DIFF
--- a/src/main/java/com/ifengxue/plugin/gui/AutoGeneratorSettingsFrame.java
+++ b/src/main/java/com/ifengxue/plugin/gui/AutoGeneratorSettingsFrame.java
@@ -140,7 +140,7 @@ public class AutoGeneratorSettingsFrame {
           assert vFile != null;
           for (TableSchema tableSchema : tableSchemaList) {
             String tableName = tableSchema.getTableName();
-            if (!config.getRemoveTablePrefix().isEmpty()) {
+            if (!config.getRemoveTablePrefix().isEmpty() && tableName.startsWith(config.getRemoveTablePrefix())) {
               tableName = tableName.substring(config.getRemoveTablePrefix().length());
             }
             String entityName = StringHelper.parseEntityName(tableName);


### PR DESCRIPTION
表名前缀存在时,tablename会错乱